### PR TITLE
localStorageに記憶→取り出しできる機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,8 @@
 !/log/.keep
 !/tmp/.keep
 
+# Ignore bundled gems
+/vendor/bundle
+
 # Ignore Byebug command history file.
 .byebug_history

--- a/app/assets/javascripts/recallable.coffee
+++ b/app/assets/javascripts/recallable.coffee
@@ -10,65 +10,53 @@ class Recallable
       target_number += 1
       clazz = "recallable_#{i}"
       $(this).addClass(clazz)
-      val = self.recall(clazz)
-      $(this).val(val) if val
+      str = self.recall(clazz)
+      $(this).val(str) if str
 
   bindEvents: ->
     instance = this
     for i in [0...target_number]
       $(".recallable_#{i}").on "focus", ->
         index = Recallable.elementToIndex(this)
-        # fat arrow の場合
-        timer[index] = setInterval( =>
-          unless printed[index] == $(this).val()
-            printed[index] = $(this).val()
-            instance.remember("recallable_#{index}", printed[index])
+        timer[index] = setInterval(=>
+          instance.remember(this, index)
         , 2000)
-      ##  thin arrow の場合
-      # $(".recallable_#{i}").on "focus", ->
-      #   index = Recallable.elementToIndex(this)
-      #   self = this
-      #   timer[index] = setInterval(->
-      #     unless printed[index] == $(self).val()
-      #       printed[index] = $(self).val()
-      #       instance.writeCookie("#{index}: #{printed[index]}")
-      #   , 2000)
       $(".recallable_#{i}").on "blur", ->
         index = Recallable.elementToIndex(this)
-        # blurのタイミングでもrememberする
-        # TODO: 関数化
-        unless printed[index] == $(this).val()
-          printed[index] = $(this).val()
-          instance.remember("recallable_#{index}", printed[index])
+        instance.remember(this, index)
         clearInterval(timer[index])
-  # 記憶する
-  remember: (clazz, val)->
-    console.log(val)
-    @setExpireMin(clazz, val, 1)
 
-  setExpireMin: (clazz, value, expire_min)->
-    unless expire_min
-      alert("expire_minが指定されていません。")
-      return
+  remember: (self, index) ->
+    unless printed[index] == $(self).val()
+      printed[index] = $(self).val()
+      @_remember("recallable_#{index}", printed[index])
+
+  _remember: (clazz, str)->
+    # 暫定(1日)
+    # TODO: ここはconfigで設定できるようにしたい。
+    expire_min = 60 * 24
     data = {
-      expire: ((new Date).getTime() + expire_min * 60) * 1000,
-      value: value
+      expire: @now() + expire_min * 60 * 1000,
+      value: str
     }
-    localStorage.setItem(@getRecallKey(clazz), JSON.stringify(data))
+    # console.log(str)
+    localStorage.setItem(@_getRecallKey(clazz), JSON.stringify(data))
 
-  getRecallKey: (clazz)->
+  _getRecallKey: (clazz)->
     "#{document.location.host}#{document.location.pathname}:#{clazz}"
 
-  # 思い出す
   recall: (clazz)->
-    # 暫定
-    console.log("read cookie and set values.")
-    val = JSON.parse(localStorage.getItem(@getRecallKey(clazz))).value
-    if val
-      console.log("Recalled: #{val}")
-      return val
+    @_recall(clazz) # or console.log("記憶しているデータがありません")
+
+  _recall: (clazz)->
+    json = JSON.parse(localStorage.getItem(@_getRecallKey(clazz)))
+    if json and json.expire and (json.expire > @now()) and json.value
+      json.value
     else
-      console.log("記憶しているデータがありません")
+      null
+
+  now: ->
+    (new Date).getTime()
 
   @elementToIndex = (tag)->
      clazz = $(tag).attr("class")

--- a/app/assets/javascripts/recallable.coffee
+++ b/app/assets/javascripts/recallable.coffee
@@ -1,20 +1,78 @@
 class Recallable
   'use strict'
-  timer = null
-  printed = null
+  target_number = 0
+  timer = []
+  printed = []
 
   constructor: ->
+    self = this
     $(".recallable").each (i)->
-      $(this).addClass("recallable_#{i}")
+      target_number += 1
+      clazz = "recallable_#{i}"
+      $(this).addClass(clazz)
+      val = self.recall(clazz)
+      $(this).val(val) if val
 
   bindEvents: ->
-    $(".recallable").on "focus", ->
-      timer = setInterval(->
-        unless printed == $("#asdf").val()
-          printed = $("#asdf").val()
-          console.log(printed)
-      , 2000)
-    $(".recallable").on "blur", ->
-      clearInterval(timer)
+    instance = this
+    for i in [0...target_number]
+      $(".recallable_#{i}").on "focus", ->
+        index = Recallable.elementToIndex(this)
+        # fat arrow の場合
+        timer[index] = setInterval( =>
+          unless printed[index] == $(this).val()
+            printed[index] = $(this).val()
+            instance.remember("recallable_#{index}", printed[index])
+        , 2000)
+      ##  thin arrow の場合
+      # $(".recallable_#{i}").on "focus", ->
+      #   index = Recallable.elementToIndex(this)
+      #   self = this
+      #   timer[index] = setInterval(->
+      #     unless printed[index] == $(self).val()
+      #       printed[index] = $(self).val()
+      #       instance.writeCookie("#{index}: #{printed[index]}")
+      #   , 2000)
+      $(".recallable_#{i}").on "blur", ->
+        index = Recallable.elementToIndex(this)
+        # blurのタイミングでもrememberする
+        # TODO: 関数化
+        unless printed[index] == $(this).val()
+          printed[index] = $(this).val()
+          instance.remember("recallable_#{index}", printed[index])
+        clearInterval(timer[index])
+  # 記憶する
+  remember: (clazz, val)->
+    console.log(val)
+    @setExpireMin(clazz, val, 1)
+
+  setExpireMin: (clazz, value, expire_min)->
+    unless expire_min
+      alert("expire_minが指定されていません。")
+      return
+    data = {
+      expire: ((new Date).getTime() + expire_min * 60) * 1000,
+      value: value
+    }
+    localStorage.setItem(@getRecallKey(clazz), JSON.stringify(data))
+
+  getRecallKey: (clazz)->
+    "#{document.location.host}#{document.location.pathname}:#{clazz}"
+
+  # 思い出す
+  recall: (clazz)->
+    # 暫定
+    console.log("read cookie and set values.")
+    val = JSON.parse(localStorage.getItem(@getRecallKey(clazz))).value
+    if val
+      console.log("Recalled: #{val}")
+      return val
+    else
+      console.log("記憶しているデータがありません")
+
+  @elementToIndex = (tag)->
+     clazz = $(tag).attr("class")
+     m = clazz.match(/recallable_([0-9]+)/)
+     parseInt(m[1])
 
 this.Recallable = Recallable


### PR DESCRIPTION
元々cookieを用いて対応する予定だったが、
cookieは容量が最大4kbと小さく、数千文字のテキストエリアだとすぐに溢れてしまうのでlocalStorageを用いることにした。